### PR TITLE
feat: add per-domain and per-path template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A lightweight Chrome extension that opens X’s post composer with the **current
 - ✅ No X API / no authentication
 - ✅ Works out of the box (no setup required)
 - ✅ Customizable template + fixed hashtags
+- ✅ **Domain/Path-specific templates** — customize templates per website (e.g., youtube.com/watch vs google.com)
 - ✅ Options UI supports **System / English / Japanese** (extensible)
 
 ## How it works
@@ -81,6 +82,42 @@ Listening: {title}
 - If your template contains `{hashtags}`, the extension inserts your fixed hashtags there.
 - If your template does **not** contain `{hashtags}`, the extension appends the hashtags to the end (on a new line).
 
+### Domain/Path Templates
+
+You can create different templates for specific domains or even specific paths within a domain. This is useful when you want different posting formats for different websites.
+
+**Priority Order** (highest to lowest):
+
+1. **Full domain + path match** — `youtube.com/watch` matches exactly `youtube.com/watch`
+2. **Path prefix match** — `youtube.com/watch` matches `youtube.com/watch?v=xxx`
+3. **Exact domain match** — `mail.google.com`
+4. **Parent domain fallback** — `google.com` matches `mail.google.com` or `drive.google.com`
+5. **Default template** — used when no specific template matches
+
+**How to use:**
+
+1. Open the Options page
+2. Click **"Add Domain/Path"**
+3. Enter a domain (e.g., `youtube.com`) or domain+path (e.g., `youtube.com/watch`)
+4. Customize the template for that specific site
+5. Save your settings
+
+**Examples:**
+
+```
+Template registrations:
+- youtube.com/watch      → "Watching: {title}"
+- youtube.com            → "YouTube: {title}"
+- mail.google.com        → "Gmail: {title}"
+- google.com             → "Google: {title}"
+
+Behavior:
+- youtube.com/watch?v=xxx     → "Watching: ..." (exact path match)
+- youtube.com/shorts/xxx      → "YouTube: ..."  (no path match, uses parent domain)
+- mail.google.com/inbox       → "Gmail: ..."    (exact domain match)
+- drive.google.com            → "Google: ..."   (parent domain fallback)
+```
+
 ## Language (System / English / Japanese)
 
 The options page lets you choose its UI language:
@@ -113,7 +150,7 @@ That’s it — the new language will appear in the language dropdown automatica
 This extension uses:
 
 - `activeTab` — read the active tab’s title and URL when you click the icon
-- `storage` — save options (template, hashtags, UI language choice)
+- `storage` — save options (template, hashtags, UI language choice, domain/path-specific templates)
 
 No external servers are used.
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -61,5 +61,41 @@
   },
   "openModePopup": {
     "message": "Popup window"
+  },
+  "domainLabel": {
+    "message": "Domain/Path Template"
+  },
+  "defaultTemplateOption": {
+    "message": "Default (All domains)"
+  },
+  "addDomainButton": {
+    "message": "Add Domain/Path"
+  },
+  "removeDomainButton": {
+    "message": "Remove"
+  },
+  "domainHint": {
+    "message": "Select a domain or domain+path to customize the template for specific websites. Examples: \"google.com\", \"mail.google.com\", \"youtube.com/watch\""
+  },
+  "addDomainPrompt": {
+    "message": "Enter domain or domain+path (e.g., example.com, mail.google.com, youtube.com/watch):"
+  },
+  "invalidDomain": {
+    "message": "Invalid format. Use: example.com or example.com/path"
+  },
+  "domainAdded": {
+    "message": "Domain/Path added (save to apply)"
+  },
+  "removeDomainConfirm": {
+    "message": "Remove template for"
+  },
+  "domainRemoved": {
+    "message": "Domain/Path removed (save to apply)"
+  },
+  "resetConfirm": {
+    "message": "Reset all settings to default?\nThis will remove all domain/path-specific templates."
+  },
+  "previewUrlLabel": {
+    "message": "Sample URL:"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -61,5 +61,41 @@
   },
   "openModePopup": {
     "message": "ポップアップ"
+  },
+  "domainLabel": {
+    "message": "ドメイン/パス別テンプレート"
+  },
+  "defaultTemplateOption": {
+    "message": "デフォルト（すべてのドメイン）"
+  },
+  "addDomainButton": {
+    "message": "ドメイン/パスを追加"
+  },
+  "removeDomainButton": {
+    "message": "削除"
+  },
+  "domainHint": {
+    "message": "特定のウェブサイト用にテンプレートをカスタマイズする場合はドメインまたはドメイン+パスを選択してください。例: \"google.com\", \"mail.google.com\", \"youtube.com/watch\""
+  },
+  "addDomainPrompt": {
+    "message": "ドメインまたはドメイン+パスを入力してください（例: example.com, mail.google.com, youtube.com/watch）:"
+  },
+  "invalidDomain": {
+    "message": "無効な形式です。example.com または example.com/path の形式で入力してください。"
+  },
+  "domainAdded": {
+    "message": "ドメイン/パスを追加しました（保存して適用）"
+  },
+  "removeDomainConfirm": {
+    "message": "以下のテンプレートを削除しますか:"
+  },
+  "domainRemoved": {
+    "message": "ドメイン/パスを削除しました（保存して適用）"
+  },
+  "resetConfirm": {
+    "message": "すべての設定をデフォルトに戻しますか？\nドメイン/パス別テンプレートもすべて削除されます。"
+  },
+  "previewUrlLabel": {
+    "message": "サンプルURL:"
   }
 }

--- a/options.css
+++ b/options.css
@@ -114,3 +114,48 @@ select.select option {
   color: var(--status);
 }
 .spacer { flex: 1; }
+
+/* Domain template section */
+.domain-template-header {
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.domain-controls {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.domain-controls .select {
+  flex: 1;
+  min-width: 200px;
+}
+
+.domain-controls .btn {
+  white-space: nowrap;
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
+/* Preview URL input */
+.preview-url-row {
+  margin-bottom: 12px;
+}
+
+.preview-url-row .label {
+  display: inline;
+  margin-right: 8px;
+  font-weight: normal;
+  opacity: 0.85;
+}
+
+.preview-url-row .input {
+  display: inline-block;
+  width: auto;
+  min-width: 300px;
+  padding: 6px 10px;
+  font-size: 13px;
+}

--- a/options.html
+++ b/options.html
@@ -20,7 +20,7 @@
           <div class="col">
             <label class="label" for="language"><span data-i18n="languageLabel">Language</span></label>
             <select id="language" class="select"></select>
-            <p class="hint" data-i18n="languageHint">Choose UI language for this options page. “System” follows your Chrome language.</p>
+            <p class="hint" data-i18n="languageHint">Choose UI language for this options page. "System" follows your Chrome language.</p>
           </div>
           <div class="col">
             <label class="label" for="hashtags"><span data-i18n="hashtagsLabel">Fixed hashtags (optional)</span></label>
@@ -31,6 +31,18 @@
       </section>
 
       <section class="card">
+        <div class="domain-template-header">
+          <label class="label" for="domainSelect"><span data-i18n="domainLabel">Domain/Path Template</span></label>
+          <div class="domain-controls">
+            <select id="domainSelect" class="select">
+              <option value="" data-i18n="defaultTemplateOption">Default (All domains)</option>
+            </select>
+            <button id="addDomainBtn" class="btn secondary" type="button" data-i18n="addDomainButton">Add Domain/Path</button>
+            <button id="removeDomainBtn" class="btn secondary" type="button" data-i18n="removeDomainButton" style="display: none;">Remove</button>
+          </div>
+          <p class="hint" data-i18n="domainHint">Select a domain or domain+path to customize the template for specific websites. Examples: "google.com", "mail.google.com", "youtube.com/watch"</p>
+        </div>
+
         <label class="label" for="template"><span data-i18n="templateLabel">Template</span></label>
         <textarea id="template" class="textarea" rows="6" spellcheck="false"></textarea>
 
@@ -46,6 +58,10 @@
             <h2 class="h2" data-i18n="previewLabel">Preview</h2>
             <p class="hint" data-i18n="previewHint">This is a preview using sample title and URL.</p>
           </div>
+        </div>
+        <div class="preview-url-row">
+          <label class="label" for="previewUrl">Sample URL:</label>
+          <input id="previewUrl" class="input" type="text" placeholder="https://example.com" />
         </div>
         <textarea id="preview" class="textarea preview" rows="6" readonly></textarea>
       </section>

--- a/options.js
+++ b/options.js
@@ -3,21 +3,30 @@ const SETTINGS_KEY = "settings";
 const DEFAULT_SETTINGS = {
   languageChoice: "system", // "system" | "en" | "ja" | ...
   template: "{title}\n{url}",
-  hashtags: ""
+  hashtags: "",
+  domainTemplates: {} // { "example.com": "template", "example.com/path": "template", ... }
 };
 
-const SAMPLE = {
+const SAMPLE_DEFAULT = {
   title: "Example Title",
   url: "https://example.com"
 };
 
+// Current editing state
+let currentKey = ""; // "" means default template, otherwise "domain.com" or "domain.com/path"
+let unsavedDomainTemplates = {}; // Store unsaved changes
+let settingsCache = null; // Cache for current settings
+
 async function getSettings() {
+  if (settingsCache) return settingsCache;
   const res = await chrome.storage.sync.get(SETTINGS_KEY);
-  return { ...DEFAULT_SETTINGS, ...(res[SETTINGS_KEY] || {}) };
+  settingsCache = { ...DEFAULT_SETTINGS, ...(res[SETTINGS_KEY] || {}) };
+  return settingsCache;
 }
 
 async function saveSettings(settings) {
   await chrome.storage.sync.set({ [SETTINGS_KEY]: settings });
+  settingsCache = { ...settings };
 }
 
 async function loadSupportedLocales() {
@@ -40,7 +49,7 @@ async function loadLocaleMessages(locale) {
   const url = chrome.runtime.getURL(`_locales/${locale}/messages.json`);
   const res = await fetch(url);
   if (!res.ok) throw new Error("Missing locale: " + locale);
-  return await res.json(); // { key: {message: "..."} }
+  return await res.json();
 }
 
 function tFromDict(dict, key) {
@@ -52,16 +61,109 @@ function normalizeTemplateNewlines(s) {
   return s.replace(/\\n/g, "\n").replace(/\/n/g, "\n");
 }
 
-function buildPostText(settings) {
-  const templateRaw = settings.template || DEFAULT_SETTINGS.template;
-  const template = normalizeTemplateNewlines(templateRaw);
+function getTemplateForKey(settings, key) {
+  if (!key) return settings.template || DEFAULT_SETTINGS.template;
+  
+  // Check unsaved changes first
+  if (unsavedDomainTemplates.hasOwnProperty(key)) {
+    return unsavedDomainTemplates[key];
+  }
+  
+  // Check saved templates
+  if (settings.domainTemplates && settings.domainTemplates[key]) {
+    return settings.domainTemplates[key];
+  }
+  
+  return settings.template || DEFAULT_SETTINGS.template;
+}
 
+function getTemplateForUrl(settings, url) {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname;
+    const pathname = urlObj.pathname;
+    
+    const templates = { ...settings.domainTemplates, ...unsavedDomainTemplates };
+    
+    // Priority 1: Full match (hostname + pathname)
+    const fullPath = hostname + pathname;
+    if (templates[fullPath]) {
+      return templates[fullPath];
+    }
+    
+    // Priority 2: Pathname prefix matches
+    const pathKeys = Object.keys(templates)
+      .filter(key => key.startsWith(hostname + '/') && pathname.startsWith(key.substring(hostname.length)))
+      .sort((a, b) => b.length - a.length);
+    
+    if (pathKeys.length > 0) {
+      return templates[pathKeys[0]];
+    }
+    
+    // Priority 3: Exact hostname match
+    if (templates[hostname]) {
+      return templates[hostname];
+    }
+    
+    // Priority 4: Parent domain match
+    const parts = hostname.split('.');
+    if (parts.length > 2) {
+      const parentDomain = parts.slice(-2).join('.');
+      if (templates[parentDomain]) {
+        return templates[parentDomain];
+      }
+    }
+    
+    return settings.template || DEFAULT_SETTINGS.template;
+  } catch {
+    return settings.template || DEFAULT_SETTINGS.template;
+  }
+}
+
+function buildPostText(settings, keyOrUrl) {
+  let templateRaw;
+  
+  if (!keyOrUrl || keyOrUrl === currentKey) {
+    // Use current editing key
+    templateRaw = getTemplateForKey(settings, currentKey);
+  } else if (keyOrUrl.startsWith('http')) {
+    // It's a URL
+    templateRaw = getTemplateForUrl(settings, keyOrUrl);
+  } else {
+    // It's a key
+    templateRaw = getTemplateForKey(settings, keyOrUrl);
+  }
+  
+  const template = normalizeTemplateNewlines(templateRaw);
   const hashtags = (settings.hashtags || "").trim();
   const hasHashtagsToken = template.includes("{hashtags}");
 
+  // Use preview URL for preview, or extract from key
+  let sampleTitle = SAMPLE_DEFAULT.title;
+  let sampleUrl = SAMPLE_DEFAULT.url;
+  
+  const previewUrlInput = byId("previewUrl");
+  if (previewUrlInput && previewUrlInput.value) {
+    sampleUrl = previewUrlInput.value;
+    try {
+      const urlObj = new URL(sampleUrl);
+      sampleTitle = `Page on ${urlObj.hostname}`;
+    } catch {
+      sampleTitle = "Page Title";
+    }
+  } else if (currentKey) {
+    // Try to construct URL from key
+    if (currentKey.includes('/')) {
+      sampleUrl = `https://${currentKey}`;
+    } else {
+      sampleUrl = `https://${currentKey}/page`;
+    }
+    sampleTitle = `Page on ${currentKey.split('/')[0]}`;
+  }
+
   let text = template
-    .replaceAll("{title}", SAMPLE.title)
-    .replaceAll("{url}", SAMPLE.url)
+    .replaceAll("{title}", sampleTitle)
+    .replaceAll("{url}", sampleUrl)
     .replaceAll("{hashtags}", hashtags);
 
   if (!hasHashtagsToken && hashtags) {
@@ -74,6 +176,19 @@ function buildPostText(settings) {
 }
 
 function byId(id) { return document.getElementById(id); }
+
+function getDisplayNameForKey(key) {
+  if (!key) {
+    return chrome.i18n.getMessage("defaultTemplateOption") || "Default (All domains)";
+  }
+  
+  // If key has path, show it clearly
+  if (key.includes('/')) {
+    return key;
+  }
+  
+  return key;
+}
 
 async function applyI18n(settings) {
   const choice = settings.languageChoice || "system";
@@ -119,6 +234,60 @@ async function populateLanguageSelect(settings) {
   select.value = settings.languageChoice || "system";
 }
 
+function populateDomainSelect(settings) {
+  const select = byId("domainSelect");
+  
+  // Save current selection
+  const previousValue = select.value;
+  
+  // Clear and rebuild options
+  select.innerHTML = "";
+  const defaultOptionLabel = chrome.i18n.getMessage("defaultTemplateOption") || "Default (All domains)";
+  select.append(new Option(defaultOptionLabel, ""));
+  
+  // Collect all keys (saved + unsaved)
+  const allKeys = new Set();
+  Object.keys(settings.domainTemplates || {}).forEach(k => allKeys.add(k));
+  Object.keys(unsavedDomainTemplates).forEach(k => allKeys.add(k));
+  
+  // Sort keys: domain-only first, then with paths
+  const sortedKeys = Array.from(allKeys).sort((a, b) => {
+    const aHasPath = a.includes('/');
+    const bHasPath = b.includes('/');
+    if (aHasPath !== bHasPath) return aHasPath ? 1 : -1;
+    return a.localeCompare(b);
+  });
+  
+  for (const key of sortedKeys) {
+    const displayName = getDisplayNameForKey(key);
+    const isUnsaved = unsavedDomainTemplates.hasOwnProperty(key) && !settings.domainTemplates?.[key];
+    const optionText = isUnsaved ? `${displayName} (unsaved)` : displayName;
+    select.append(new Option(optionText, key));
+  }
+  
+  // Restore selection or use currentKey
+  if (currentKey && Array.from(select.options).some(opt => opt.value === currentKey)) {
+    select.value = currentKey;
+  } else if (previousValue && Array.from(select.options).some(opt => opt.value === previousValue)) {
+    select.value = previousValue;
+    currentKey = previousValue;
+  } else {
+    select.value = "";
+    currentKey = "";
+  }
+  
+  updateRemoveButtonVisibility();
+}
+
+function updateRemoveButtonVisibility() {
+  const removeBtn = byId("removeDomainBtn");
+  if (currentKey) {
+    removeBtn.style.display = "inline-block";
+  } else {
+    removeBtn.style.display = "none";
+  }
+}
+
 function setStatus(text) {
   const el = byId("status");
   el.textContent = text || "";
@@ -127,54 +296,241 @@ function setStatus(text) {
   setStatus._t = window.setTimeout(() => { el.textContent = ""; }, 1800);
 }
 
+function parseDomainInput(input) {
+  // Remove protocol if present
+  let cleanInput = input.trim().replace(/^https?:\/\//, '');
+  
+  // Remove query string and hash
+  cleanInput = cleanInput.split('?')[0].split('#')[0];
+  
+  // Validate format
+  // Accept: domain.com, domain.com/path, sub.domain.com, sub.domain.com/path
+  const parts = cleanInput.split('/');
+  const domainPart = parts[0];
+  const pathPart = parts.length > 1 ? '/' + parts.slice(1).join('/') : '';
+  
+  // Domain validation
+  const domainPattern = /^[a-zA-Z0-9][a-zA-Z0-9-]*(\.[a-zA-Z0-9][a-zA-Z0-9-]*)+$/;
+  if (!domainPattern.test(domainPart)) {
+    return null;
+  }
+  
+  // Path validation (should start with / and contain valid characters)
+  if (pathPart && !pathPart.match(/^\/[a-zA-Z0-9_\-\/.]*$/)) {
+    return null;
+  }
+  
+  return pathPart ? domainPart + pathPart : domainPart;
+}
+
 async function main() {
   const settings = await getSettings();
+  
+  // Initialize unsaved domain templates with saved ones
+  unsavedDomainTemplates = { ...(settings.domainTemplates || {}) };
 
   await populateLanguageSelect(settings);
   await applyI18n(settings);
+  populateDomainSelect(settings);
 
+  // Set initial values
   byId("template").value = settings.template || DEFAULT_SETTINGS.template;
   byId("hashtags").value = settings.hashtags || "";
+  byId("previewUrl").value = SAMPLE_DEFAULT.url;
+  byId("preview").value = buildPostText(settings, currentKey);
 
-  byId("preview").value = buildPostText(settings);
+  // Domain selection change handler
+  byId("domainSelect").addEventListener("change", async () => {
+    const select = byId("domainSelect");
+    currentKey = select.value;
+    
+    // Get template for selected key
+    const template = getTemplateForKey(settings, currentKey);
+    byId("template").value = template;
+    
+    // Update preview URL based on selection
+    if (currentKey) {
+      if (currentKey.includes('/')) {
+        byId("previewUrl").value = `https://${currentKey}`;
+      } else {
+        byId("previewUrl").value = `https://${currentKey}/sample-page`;
+      }
+    } else {
+      byId("previewUrl").value = SAMPLE_DEFAULT.url;
+    }
+    
+    // Update preview
+    byId("preview").value = buildPostText(settings, currentKey);
+    
+    updateRemoveButtonVisibility();
+  });
 
-  const refreshPreview = async () => {
+  // Add domain button handler
+  byId("addDomainBtn").addEventListener("click", async () => {
+    const promptMsg = chrome.i18n.getMessage("addDomainPrompt") || 
+      "Enter domain or domain+path (e.g., example.com, mail.google.com, youtube.com/watch):";
+    const input = prompt(promptMsg);
+    if (!input) return;
+    
+    const key = parseDomainInput(input);
+    if (!key) {
+      const errorMsg = chrome.i18n.getMessage("invalidDomain") || 
+        "Invalid format. Use: example.com or example.com/path";
+      alert(errorMsg);
+      return;
+    }
+    
+    // Add to unsaved domain templates with current template value
+    const currentTemplate = byId("template").value;
+    unsavedDomainTemplates[key] = currentTemplate;
+    
+    // Update select and select the new key
+    populateDomainSelect(settings);
+    byId("domainSelect").value = key;
+    currentKey = key;
+    
+    // Update preview URL
+    if (key.includes('/')) {
+      byId("previewUrl").value = `https://${key}`;
+    } else {
+      byId("previewUrl").value = `https://${key}/sample-page`;
+    }
+    
+    updateRemoveButtonVisibility();
+    const successMsg = chrome.i18n.getMessage("domainAdded") || "Domain/Path added (save to apply)";
+    setStatus(successMsg);
+  });
+
+  // Remove domain button handler
+  byId("removeDomainBtn").addEventListener("click", async () => {
+    if (!currentKey) return;
+    
+    const confirmKey = chrome.i18n.getMessage("removeDomainConfirm") || "Remove template for";
+    if (!confirm(`${confirmKey} "${currentKey}"?`)) return;
+    
+    // Remove from unsaved templates
+    delete unsavedDomainTemplates[currentKey];
+    
+    // Also remove from settings cache to immediately update the dropdown
+    if (settings.domainTemplates && settings.domainTemplates[currentKey]) {
+      delete settings.domainTemplates[currentKey];
+    }
+    
+    // Update select and switch to default
+    populateDomainSelect(settings);
+    byId("domainSelect").value = "";
+    currentKey = "";
+    
+    // Reset template to default
+    byId("template").value = settings.template || DEFAULT_SETTINGS.template;
+    byId("previewUrl").value = SAMPLE_DEFAULT.url;
+    byId("preview").value = buildPostText(settings, currentKey);
+    
+    updateRemoveButtonVisibility();
+    const removedMsg = chrome.i18n.getMessage("domainRemoved") || "Domain/Path removed (save to apply)";
+    setStatus(removedMsg);
+  });
+
+  // Template input handler
+  byId("template").addEventListener("input", async () => {
+    const template = byId("template").value;
+    
+    if (currentKey) {
+      // Update unsaved domain template
+      unsavedDomainTemplates[currentKey] = template;
+    }
+    
+    // Update preview
     const cur = await getSettings();
-    cur.template = byId("template").value;
+    cur.domainTemplates = { ...cur.domainTemplates, ...unsavedDomainTemplates };
+    byId("preview").value = buildPostText(cur, currentKey);
+  });
+
+  // Preview URL input handler
+  byId("previewUrl").addEventListener("input", async () => {
+    const cur = await getSettings();
+    cur.domainTemplates = { ...cur.domainTemplates, ...unsavedDomainTemplates };
+    byId("preview").value = buildPostText(cur, byId("previewUrl").value);
+  });
+
+  // Hashtags input handler
+  byId("hashtags").addEventListener("input", async () => {
+    const cur = await getSettings();
     cur.hashtags = byId("hashtags").value;
-    byId("preview").value = buildPostText(cur);
-  };
+    cur.domainTemplates = { ...cur.domainTemplates, ...unsavedDomainTemplates };
+    byId("preview").value = buildPostText(cur, byId("previewUrl").value);
+  });
 
-  byId("template").addEventListener("input", refreshPreview);
-  byId("hashtags").addEventListener("input", refreshPreview);
-
+  // Language change handler
   byId("language").addEventListener("change", async () => {
     const cur = await getSettings();
     cur.languageChoice = byId("language").value;
     await saveSettings(cur);
+    settings.languageChoice = cur.languageChoice;
     await applyI18n(cur);
     setStatus(chrome.i18n.getMessage("saved") || "Saved");
   });
 
+  // Save button handler
   byId("save").addEventListener("click", async () => {
     const cur = await getSettings();
-    cur.template = byId("template").value;
+    
+    // Merge unsaved templates
+    cur.domainTemplates = { ...cur.domainTemplates, ...unsavedDomainTemplates };
+    
+    // If editing default, save the template
+    if (!currentKey) {
+      cur.template = byId("template").value;
+    } else {
+      // Ensure the current key's template is saved
+      cur.domainTemplates[currentKey] = byId("template").value;
+    }
+    
     cur.hashtags = byId("hashtags").value;
     cur.languageChoice = byId("language").value;
 
     await saveSettings(cur);
-    byId("preview").value = buildPostText(cur);
+    
+    // Update settings reference
+    Object.assign(settings, cur);
+    
+    // Refresh UI
+    populateDomainSelect(settings);
+    byId("preview").value = buildPostText(settings, byId("previewUrl").value);
     setStatus(chrome.i18n.getMessage("saved") || "Saved");
   });
 
+  // Reset button handler
   byId("reset").addEventListener("click", async () => {
+    const confirmMsg = chrome.i18n.getMessage("resetConfirm") || 
+      "Reset all settings to default?\nThis will remove all domain/path-specific templates.";
+    if (!confirm(confirmMsg)) return;
+    
     const cur = await getSettings();
     cur.template = DEFAULT_SETTINGS.template;
     cur.hashtags = "";
+    cur.domainTemplates = {};
+    cur.languageChoice = "system";
+    
     await saveSettings(cur);
+    
+    // Update settings reference
+    Object.assign(settings, cur);
+    settings.domainTemplates = {};
+    
+    // Reset editing state
+    unsavedDomainTemplates = {};
+    currentKey = "";
+    
+    // Update UI
     byId("template").value = cur.template;
-    byId("hashtags").value = cur.hashtags;
-    byId("preview").value = buildPostText(cur);
+    byId("hashtags").value = "";
+    byId("language").value = "system";
+    byId("previewUrl").value = SAMPLE_DEFAULT.url;
+    populateDomainSelect(settings);
+    await applyI18n(cur);
+    byId("preview").value = buildPostText(cur, currentKey);
+    updateRemoveButtonVisibility();
     setStatus(chrome.i18n.getMessage("resetDone") || "Reset");
   });
 }

--- a/service_worker.js
+++ b/service_worker.js
@@ -7,7 +7,8 @@ const SETTINGS_KEY = "settings";
 const DEFAULT_SETTINGS = {
   languageChoice: "system",   // "system" | "en" | "ja" | ...
   template: "{title}\n{url}",
-  hashtags: ""
+  hashtags: "",
+  domainTemplates: {}  // { "example.com": "template", "example.com/path": "template", ... }
 };
 
 async function getSettings() {
@@ -21,8 +22,61 @@ function normalizeTemplateNewlines(s) {
   return s.replace(/\\n/g, "\n").replace(/\/n/g, "\n");
 }
 
+function parseUrl(url) {
+  try {
+    const urlObj = new URL(url);
+    return {
+      hostname: urlObj.hostname,
+      pathname: urlObj.pathname
+    };
+  } catch {
+    return { hostname: "", pathname: "" };
+  }
+}
+
+function getTemplateForUrl(settings, url) {
+  const { hostname, pathname } = parseUrl(url);
+  if (!hostname) return settings.template || DEFAULT_SETTINGS.template;
+  
+  const templates = settings.domainTemplates || {};
+  
+  // Priority 1: Full match (hostname + pathname, e.g., "google.com/test")
+  // Try exact pathname match first
+  const fullPath = hostname + pathname;
+  if (templates[fullPath]) {
+    return templates[fullPath];
+  }
+  
+  // Try pathname prefix matches (e.g., "google.com/test" matches "google.com/test/page")
+  // Sort keys by length (longer = more specific) to check most specific first
+  const pathKeys = Object.keys(templates)
+    .filter(key => key.startsWith(hostname + '/') && pathname.startsWith(key.substring(hostname.length)))
+    .sort((a, b) => b.length - a.length);
+  
+  if (pathKeys.length > 0) {
+    return templates[pathKeys[0]];
+  }
+  
+  // Priority 2: Exact hostname match (e.g., "mail.google.com")
+  if (templates[hostname]) {
+    return templates[hostname];
+  }
+  
+  // Priority 3: Parent domain match (e.g., "blog.example.com" -> "example.com")
+  const parts = hostname.split('.');
+  if (parts.length > 2) {
+    const parentDomain = parts.slice(-2).join('.');
+    if (templates[parentDomain]) {
+      return templates[parentDomain];
+    }
+  }
+  
+  // Priority 4: Default template
+  return settings.template || DEFAULT_SETTINGS.template;
+}
+
 function buildPostText({ title, url }, settings) {
-  const templateRaw = settings.template || DEFAULT_SETTINGS.template;
+  const templateRaw = getTemplateForUrl(settings, url);
   const template = normalizeTemplateNewlines(templateRaw);
 
   const hashtags = (settings.hashtags || "").trim();


### PR DESCRIPTION
## Summary

This PR implements domain-specific and path-specific template customization, allowing users to create different posting templates for different websites or even specific paths within websites.

### Changes

- Added domain/path template storage in settings
- Implemented priority-based template selection:
  1. Full domain + path match (e.g., `youtube.com/watch`)
  2. Path prefix match (e.g., `youtube.com/watch` matches `youtube.com/watch?v=xxx`)
  3. Exact domain match (e.g., `mail.google.com`)
  4. Parent domain fallback (e.g., `google.com` matches subdomains)
  5. Default template (fallback)

### UI Updates

- Added domain/path selection dropdown in Options page
- Added "Add Domain/Path" button with input validation
- Added "Remove" button for deleting domain/path templates
- Added preview URL input for testing templates
- Updated i18n strings for English and Japanese

### Files Modified

- `service_worker.js` - Template selection logic based on URL
- `options.html` - UI for domain/path selection
- `options.js` - Domain/path management and template preview
- `options.css` - Styling for new UI elements
- `_locales/en/messages.json` - English translations
- `_locales/ja/messages.json` - Japanese translations
- `README.md` - Documentation for new feature

### Usage Example

```
Registered templates:
- youtube.com/watch → "Watching: {title}"
- youtube.com       → "YouTube: {title}"
- mail.google.com   → "Gmail: {title}"
- google.com        → "Google: {title}"

Behavior:
- youtube.com/watch?v=xxx → "Watching: ..." (path match)
- youtube.com/shorts/xxx  → "YouTube: ..."  (parent domain)
- mail.google.com/inbox   → "Gmail: ..."    (exact domain)
- drive.google.com        → "Google: ..."   (parent domain fallback)
```

## 概要

このPRでは、ドメイン別およびパス別のテンプレートカスタマイズ機能を実装しました。ユーザーは、異なるウェブサイトや、特定のパスごとに異なる投稿テンプレートを作成できるようになりました。

### 変更点

- 設定にドメイン/パステンプレートの保存機能を追加
- 優先順位ベースのテンプレート選択を実装:
  1. ドメイン+パスの完全一致 (例: `youtube.com/watch`)
  2. パスの前方一致 (例: `youtube.com/watch` が `youtube.com/watch?v=xxx` に一致)
  3. ドメインの完全一致 (例: `mail.google.com`)
  4. 親ドメインのフォールバック (例: `google.com` がサブドメインに一致)
  5. デフォルトテンプレート (フォールバック)

### UIの更新

- オプションページにドメイン/パス選択ドロップダウンを追加
- 入力検証付き「ドメイン/パスを追加」ボタンを追加
- ドメイン/パステンプレート削除用の「削除」ボタンを追加
- テンプレートテスト用のプレビューURL入力欄を追加
- 英語と日本語のi18n文字列を更新

### 変更されたファイル

- `service_worker.js` - URLに基づくテンプレート選択ロジック
- `options.html` - ドメイン/パス選択用UI
- `options.js` - ドメイン/パス管理とテンプレートプレビュー
- `options.css` - 新しいUI要素のスタイリング
- `_locales/en/messages.json` - 英語翻訳
- `_locales/ja/messages.json` - 日本語翻訳
- `README.md` - 新機能のドキュメント

### 使用例

```
登録されたテンプレート:
- youtube.com/watch → "Watching: {title}"
- youtube.com       → "YouTube: {title}"
- mail.google.com   → "Gmail: {title}"
- google.com        → "Google: {title}"

動作:
- youtube.com/watch?v=xxx → "Watching: ..." (パス一致)
- youtube.com/shorts/xxx  → "YouTube: ..."  (親ドメイン)
- mail.google.com/inbox   → "Gmail: ..."    (ドメイン一致)
- drive.google.com        → "Google: ..."   (親ドメインフォールバック)
```

Closes #2
